### PR TITLE
Fixed handling of Enter key and cursor placement

### DIFF
--- a/static/live-core.js
+++ b/static/live-core.js
@@ -511,9 +511,10 @@ SymPy.Shell = Ext.extend(Ext.util.Observable, {
                     }
 
                     var start = value.slice(0, cursor);
-                    var end = value.slice(cursor+1);
+                    var end = value.slice(cursor);
 
                     this.setValue(start + '\n' + spaces + end);
+                    this.setCursor(cursor + 1 + spaces.length);
 
                     event.stopEvent();
                     return true;


### PR DESCRIPTION
This pull request fixes the odd behavior of Enter key (it should not eat any characters anymore). I also fixed cursor placement (previously it ended up at the end of the new line).
