### PR TITLE
GCI Task bug fix: Disabled execution of empty (pure whitespace or zero length) statements.

### DIFF
--- a/static/live-core.js
+++ b/static/live-core.js
@@ -596,12 +596,15 @@ SymPy.Shell = Ext.extend(Ext.util.Observable, {
     },
 
     evaluate: function() {
-        if (!this.evaluating) {
+        var statement = this.promptEl.getValue();
+        // make sure the statement is not only whitespace
+        // use statement != "" if pure whitespace should be evaluated
+        if (!this.evaluating && !statement.match(/^\s*$/)) {
             this.evaluating = true;
             this.promptEl.addClass('sympy-live-processing');
 
             var data = {
-                statement: this.promptEl.getValue(),
+                statement: statement,
                 printer: this.printerEl.getValue(),
                 session: this.session || null
             };


### PR DESCRIPTION
Any statement that matches the regex /^\s*$/ will not be executed.

Meaning any statement that contains either no characters or pure whitespace.

For Google Code-In task "DON'T ALLOW EMPTY EXECUTION IN SYMPY LIVE"
http://www.google-melange.com/gci/task/view/google/gci2011/7193395
