### PR TITLE
Fix link to the docs

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -116,7 +116,7 @@ from sympy import *
 VERBOSE_MESSAGE = """\
 These commands were executed:
 %(source)s
-Documentation can be found at <a href="http://docs.sympy.org/">http://docs.sympy.org/</a>\
+Documentation can be found at <a href="http://docs.sympy.org/">http://docs.sympy.org/</a>.\
 """
 
 


### PR DESCRIPTION
Now that SymPy Live is essentially at sympy.org, it doesn't make sense
to link there. So put a link to docs.sympy.org, and make it linkified.

This also clears some whitespace.
