### PR TITLE
Fix the logo link in the mobile version

### DIFF
--- a/templates/shellmobile.html
+++ b/templates/shellmobile.html
@@ -67,7 +67,7 @@
   </head>
   <body>
     <div id="header">
-      <h1><a href="index.html"><img src="static/logo.png" style="vertical-align:middle" alt="SymPy Logo" /> SymPy Live</a></h1>
+      <h1><a href=""><img src="static/logo.png" style="vertical-align:middle" alt="SymPy Logo" /> SymPy Live</a></h1>
       <button id="menu">&#8942;</button>
     </div>
     <div id="user">


### PR DESCRIPTION
It pointed to live.sympy.org/index.html, which doesn't exist.
