### PR TITLE
[GCI 2011] Zoom problem mobile fix

### DIFF
--- a/static/live-mobile.css
+++ b/static/live-mobile.css
@@ -9,7 +9,7 @@ body {
     background-color: #f5f5f5;
     overflow: scroll;
     -webkit-overflow-scrolling: touch;
-    margin: 0 3px 10px 3px;
+    margin: 6px 6px 10px 6px;
     height: 300px;
     min-width: 200px;
 }


### PR DESCRIPTION
This fixes an issue mentioned at http://code.google.com/p/sympy/issues/detail?id=2872.
- Adjusted width of output field so that it fits within the screen
- Set `user-scalable=no` to disable zooming

This is a GCI task: http://www.google-melange.com/gci/task/view/google/gci2011/7233316
