### PR TITLE
Larger Fullscreen

### DIFF
--- a/static/live-core.js
+++ b/static/live-core.js
@@ -1003,7 +1003,7 @@ SymPy.Shell = Ext.extend(Ext.util.Observable, {
                 }, 100);
                 $('.sympy-live-output').css({
                     'width' : bwidth-32,
-                    'height' : bheight-250-160
+                    'height' : bheight-250-160+100
                 });
             }
 


### PR DESCRIPTION
Currently when one presses the "fullscreen" button, the screen only gets larger in width so there is lots of empty space at the bottom. This adds height to the fullscreen mode so it actually takes up the whole screen.
