### PR TITLE
Use the fast option when pickling values.  Fixes issue 2587.

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -55,6 +55,7 @@ from google.appengine.api import users
 from google.appengine.ext import db
 from google.appengine.ext import webapp
 from google.appengine.ext.webapp import template
+from google.appengine.runtime.apiproxy_errors import RequestTooLargeError 
 
 sys.path.insert(0, os.path.join(os.getcwd(), 'sympy'))
 
@@ -427,9 +428,9 @@ class Live(object):
 
         try:
             session.put()
-        except:
-            if stream.len == 0:
-                self.error(stream, ('ERROR: Unable to store value due to excessive size.',)) 
+        except RequestTooLargeError:
+            stream.truncate(0) # clear output
+            self.error(stream, ('Unable to process statement due to its excessive size.',))
 
 class Session(db.Model):
   """A shell session. Stores the session's globals.


### PR DESCRIPTION
Before:

```
>>> f = x**2+x**-2
>>> f
 2    -2
x  + x  
>>> f = 1/(x**2*(x**2+1))
>>> f
      1      
-------------
 2 / 1      \
x *|---- + 1|
   |/1 \    |
   ||--|    |
   || 2|    |
   \\x /    /
```

After:

```
>>> f = x**2+x**-2
>>> f
 2   1 
x  + --
      2
     x 
>>> f = 1/(x**2*(x**2+1))
>>> f
     1     
-----------
 2 / 2    \
x *\x  + 1/
```

See the issue for more details.

Issue 2587: http://code.google.com/p/sympy/issues/detail?id=2587

GCI Task: http://www.google-melange.com/gci/task/view/google/gci2011/7179246
