### PR TITLE
[Issue 2930] Change button colors to match top links

### DIFF
--- a/static/live-core.css
+++ b/static/live-core.css
@@ -69,9 +69,26 @@ button {
     margin-bottom: 0.5em;
 }
 .sympy-live-toolbar > button {
-    margin-left: 0.5em;
-    background-color: #3b5526;
-    color: #FFF;
+  margin-left: 0.5em;
+  -moz-transition: all .5s ease-out;
+  -webkit-transition: all .5s ease-out;
+  -o-transition: all .5s ease-out;
+  transition: all .5s ease-out;
+  background-color: #3b5526;
+  color: #FFF;
+  font-weight: bold;
+}
+.sympy-live-toolbar > button:hover {
+  margin-left: 0.5em;
+  color: #FFF;
+  background-color: #5B7745;
+  -moz-transition: all .2s ease-in;
+  -webkit-transition: all .2s ease-in;
+  -o-transition: all .2s ease-in;
+  transition: all .2s ease-in;
+}
+.sympy-live-toolbar > button:first-child {
+  background-color: #81B953;
 }
 
 .sympy-live-processing {


### PR DESCRIPTION
Changes:
- Clear/Fullscreen button highlight behavior matches buttons on top (background color fades, no font color change)
- Evaluate button made light green
- Buttons have bold font, as with top buttons

This is a patch for issue 2930: http://code.google.com/p/sympy/issues/detail?id=2930
