### PR TITLE
Compatibility with old jQuery

### DIFF
--- a/static/live-core.js
+++ b/static/live-core.js
@@ -12,6 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
+// Taken directly from jQuery source (MIT) - needed because Sphinx uses an
+// old jQuery. Remove if using Sphinx >= 1.2
+if (!jQuery.isNumeric) {
+    jQuery.isNumeric = function( obj ) {
+	    return !isNaN( parseFloat(obj) ) && isFinite( obj );
+    };
+}
+if (!jQuery.fn.on) {
+    jQuery.fn.on = jQuery.fn.bind;
+}
+if (!jQuery.fn.prop) {
+    jQuery.fn.prop = jQuery.fn.attr;
+}
+
 utilities.namespace("SymPy");
 
 SymPy.Keys = {

--- a/static/live-sphinx.js
+++ b/static/live-sphinx.js
@@ -323,7 +323,7 @@ SymPy.SphinxShell = SymPy.Shell.$extend({
 $(document).ready(function() {
     var path = SymPy.getBasePath('live-sphinx.js');
 
-    $.get(path + '/sphinxbanner').done(function(data) {
+    $.get(path + '/sphinxbanner', function(data) {
         var shellEl = $('<div id="shell"/>').appendTo($(document.body));
         var settingsEl = $('<div id="settings"><div class="content"></div></div>');
         settingsEl.appendTo(shellEl);  // Needed to render the shell


### PR DESCRIPTION
The Sphinx extension loads its own jQuery library, which unfortunately overrides some methods that Sphinx uses for search. Also, the Live extension can't use the old jQuery version by default, so this adds some workarounds. Once Sphinx 1.2 is released, this will become unnecessary.
