### PR TITLE
Bugfixes

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -36,6 +36,7 @@ your app.yaml.
 TODO: unit tests!
 """
 
+import ast
 import logging
 import new
 import os
@@ -321,6 +322,13 @@ class Live(object):
         """Evaluate the statement in sessions's globals. """
         # the Python compiler doesn't like network line endings
         source = statement.replace('\r\n', '\n').rstrip()
+
+        try:
+            # check for a SyntaxError now; this way the user will see their
+            # original statement and not the transformed one
+            ast.parse(source)
+        except SyntaxError:
+            return self.error(stream, self.syntaxerror())
 
         # convert int to Integer (1/2 -> Integer(1)/Integer(2))
         source = int_to_Integer(source)


### PR DESCRIPTION
Changes:
- Initialize `old_globals` after unpickling global variables
- Use `int_to_Integer` on statements

Fixes [issue 3310](https://code.google.com/p/sympy/issues/detail?id=3310) and [issue 3357](https://code.google.com/p/sympy/issues/detail?id=3357).

Deployed at http://68.sympy-live-tests.appspot.com/

Example for issue 3310: http://68.sympy-live-tests.appspot.com/?evaluate=1%2F3%0A%23--%0Ax**(1%2F5)%0A%23--%0A

Example for issue 3357: http://68.sympy-live-tests.appspot.com/?evaluate=variable%20%3D%2013%0A%23--%0Adef%20test()%3A%20print%20variable%0A%23--%0Atest()%0A%23--%0A
