### PR TITLE
Fix issues 3863, 3864

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -372,12 +372,14 @@ class Live(object):
         old_main = sys.modules.get('__main__')
 
         try:
+            old_globals = {}
             sys.modules['__main__'] = statement_module
             statement_module.__name__ = '__main__'
 
             # re-evaluate the unpicklables
             for code in session.unpicklables:
                 exec code in statement_module.__dict__
+                exec code in old_globals
 
             # re-initialize the globals
             session_globals_dict = session.globals_dict()
@@ -385,10 +387,9 @@ class Live(object):
             for name, val in session_globals_dict.items():
                 try:
                     statement_module.__dict__[name] = val
+                    old_globals[name] = val
                 except:
                     session.remove_global(name)
-
-            old_globals = dict(statement_module.__dict__)
 
             # re-initialize '_' special variable
             __builtin__._ = session_globals_dict.get('_')


### PR DESCRIPTION
Changes:
- Delete variables in the datastore that were deleted by the session
- Initialize `old_globals` separately and not as a copy of the statement module. I tried `copy.deepcopy` but it [doesn't work on types that reference a module](http://stackoverflow.com/questions/1941887/how-can-i-debug-a-problem-calling-pythons-copy-deepcopy-against-a-custom-type) and I wanted to avoid monkeypatching a private API.

Fixes [issue 3863](https://code.google.com/p/sympy/issues/detail?id=3863) and [issue 3864](https://code.google.com/p/sympy/issues/detail?id=3864).
