### PR TITLE
Reinitialize old_globals separately for picklables

### DIFF
--- a/static/live-core.js
+++ b/static/live-core.js
@@ -853,7 +853,9 @@ SymPy.Shell = Class.$extend({
     },
 
     error: function(xhr, status, error) {
-        console.log("Error:", xhr, status, error);
+        console.log("Error:", xhr.statusText);
+        console.log(xhr.responseText)
+        console.log(status, error);
 
         var errorMessage = "Unspecified error.";
 


### PR DESCRIPTION
Addresses a few issues:
- If a statement creates an unpicklable and that statement contained
  a print statement, subsequent requests would fail as reevaluating
  that statement would cause output to be sent to the browser, leading
  to syntax errors when the JavaScript tried to parse the request.
- When reinitializing `old_globals`, unpickle the values separately so
  that it doesn't share a mutable value with the session globals.
- Delete `__builtin__` before deciding whether to pickle the globals
  or store the statement; sometimes it was being modified, leading
  to statements being stored as unpicklable when this was not true.
  This caused behavior where the value of a variable would change
  upon each request.

Addresses [issue 3872](https://code.google.com/p/sympy/issues/detail?id=3872). Unfortunately, if a statement that makes an unpicklable does create a mutable variable, then you will still get variables that change on every request, simply because of how Live works. So the tutorial will still behave strangely.
