### PR TITLE
Show that init_printing() is run

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -123,7 +123,9 @@ _ = None
 PREEXEC_MESSAGE = """\
 from __future__ import division
 from sympy import *
-""" + PREEXEC
+""" + PREEXEC + """\
+init_printing()
+"""
 
 VERBOSE_MESSAGE = """\
 These commands were executed:


### PR DESCRIPTION
This matches https://github.com/sympy/sympy/pull/7375. Some people get
confused how the printing is enabled in SymPy Live. This will show them how to
do it in a regular session.
