### PR TITLE
bugfix/firstindent

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -237,14 +237,15 @@ class Live(object):
         sys.last_type = etype
         sys.last_value = value
 
-        if etype is SyntaxError:
-            try:
-                msg, (dummy_filename, line, offset, source) = value
-            except:
-                pass
-            else:
-                value = SyntaxError(msg, (self._file, line, offset, source))
-                sys.last_value = value
+        # extract info from error value (specifcally, we want the line number)
+        try:
+            msg, (dummy_filename, line, offset, source) = value
+        except:
+            pass
+        else:
+            # re-package error with `self._file` instead of `dummy_filename`
+            value = etype(msg, (self._file, line, offset, source))
+            sys.last_value = value
 
         text = [self._header]
         text = text + traceback.format_exception_only(etype, value)

--- a/shell.py
+++ b/shell.py
@@ -334,6 +334,10 @@ class Live(object):
         # the Python compiler doesn't like network line endings
         source = statement.replace('\r\n', '\n').rstrip()
 
+        # allow spaces before one-liners (to emulate Python shell's behaviour)
+        if '\n' not in source:
+            source = source.lstrip()
+
         try:
             # check for a SyntaxError now; this way the user will see their
             # original statement and not the transformed one


### PR DESCRIPTION
This PR fixes an edge case of one-line inputs with leading spaces reported in #102

```
>>>  2+2        # (the input is ' 2+2')
```
Causes error, and error is not handled.

This behaviour is different from the default Python shell, which is tolerant of "bad" indentation. By `lstrip`-ing single-line inputs the problem goes away:

```
>>>  2+2
4
```

This PR also contains a change to the helper function `syntaxerror` whose goal is to extract the line number. This function was previously not able to handle IndentationError (a subtype of SyntaxError). Now is handles it correctly.