### PR TITLE
Switch to new MathJax CDN (fixes #107)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -43,7 +43,7 @@
       });
     </script>
 
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>
+    <script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_CHTML-full"></script>
 
     <script type="text/javascript">
       $(document).ready(function() {


### PR DESCRIPTION
This also uses the new CommonHTML renderer, which will become default in the future.