### PR TITLE
Fix for numpy.ndarray compare bug repored in #110

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -52,6 +52,7 @@ import rlcompleter
 import traceback
 import datetime
 
+import numpy                       # uses version bundled with GAE: numpy==1.6.1
 from StringIO import StringIO
 
 from google.appengine.api import users
@@ -449,8 +450,18 @@ class Live(object):
             # extract the new globals that this statement added
             new_globals = {}
 
+            def should_update(val, old_val):
+                """
+                Returns True if `val` and `old_val` are different or if `val` is
+                of type `numpy.ndarray`.
+                """
+                if type(val) is numpy.ndarray:
+                    return True
+                else:
+                    return not (val == old_val)
+
             for name, val in statement_module.__dict__.items():
-                if name not in old_globals or val != old_globals[name]:
+                if name not in old_globals or should_update(val, old_globals[name]):
                     new_globals[name] = val
 
             for name in old_globals:


### PR DESCRIPTION
Without the new `should_update` check, we get the error:
```
    ValueError: The truth value of an array with more than one element is ambiguous.
```
because numpy.ndarray objects cannot be compared with == and !=.
See https://github.com/sympy/sympy-live/issues/110

We choose to always update `new_globals[name]` when `val` is of type `numpy.ndarray`.