### PR TITLE
Fix static url regex to include upper case characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,8 +154,11 @@ to use ``dev_appserver.py``.
 
 Branch builds are automatically deployed by Travis to
 `https://<BRANCH-NAME>-dot-sympy-live-hrd.appspot.com/`.
-Note that the pull request has to from a branch on this repository, as
-forks do not have access to the key to deploy to the app engine.
+Note that branch has to be on this repository, as forks
+do not have access to the key to deploy to the app engine,
+and branch name should match the regex: `[0-9a-zA-Z-_]`
+(See app.yaml to check out the static files regex) for
+the static files to load properly
 
 Development notes
 -----------------

--- a/app.yaml
+++ b/app.yaml
@@ -40,7 +40,7 @@ handlers:
 
 # cache-busting scheme
 # request /static-(app version)/filename
-- url: /static-[0-9a-z]+/(.*)
+- url: /static-[0-9a-zA-Z]+/(.*)
   static_files: static/\1
   upload: static/(.*)
   secure: always

--- a/app.yaml
+++ b/app.yaml
@@ -40,7 +40,7 @@ handlers:
 
 # cache-busting scheme
 # request /static-(app version)/filename
-- url: /static-[0-9a-zA-Z]+/(.*)
+- url: /static-[0-9a-zA-Z-_]+/(.*)
   static_files: static/\1
   upload: static/(.*)
   secure: always


### PR DESCRIPTION
Fixes #150 

Since the application version could be upper case characters as well, for example while developing locally, it is `None`