### PR TITLE
Run Cloud Datastore Emulator to avoid using credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ install:
   - ls
 
 before_script:
+  - gcloud version || true
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf "$HOME/google-cloud-sdk"; curl https://sdk.cloud.google.com | bash > /dev/null; fi
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud version
+  - gcloud components install cloud-datastore-emulator --quiet
+  - gcloud beta emulators datastore start &
   - cd ..
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip -nv
   - unzip -q google_appengine_1.9.90.zip
@@ -22,7 +28,7 @@ before_script:
   - unzip -q chromedriver_linux64.zip
   - cp chromedriver $HOME/bin/
   - cd $TRAVIS_BUILD_DIR
-  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . &
+  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . &  --env_var DATASTORE_EMULATOR_HOST=localhost:8081 --env_var DATASTORE_USE_PROJECT_ID_AS_APP_ID=true &
   - pip install selenium pytest
 script:
   - pytest tests -v
@@ -47,3 +53,8 @@ deploy:
 after_deploy:
   - pip install requests
   - python bin/update_status_on_pr.py
+
+env:
+  global:
+    # Do not prompt for user input when using any SDK methods.
+    - CLOUDSDK_CORE_DISABLE_PROMPTS=1

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,14 @@ We use submodules to include external libraries in sympy-live::
 This is sufficient to clone appropriate repositories in correct versions
 into sympy-live (see git documentation on submodules for information).
 
+You will need to install Datastore Emulator as well, which comes from gcloud's SDK,
+install the Google Cloud SDK for your OS from here: https://cloud.google.com/sdk/install
+Then run the following commands to install and run the datastore emulator in the background::
+
+    gcloud components install cloud-datastore-emulator --quiet
+    gcloud beta emulators datastore start &
+
+
 Development server
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,13 @@ Install testing requirements::
 
 Start the application in the background, (See instructions above to start the app).
 
+You would need Google Chrome browser installed for running these tests:
+Download it from here: https://www.google.com/chrome/
+
+You would also need chrome driver (for your chrome version). Download it from here:
+https://chromedriver.storage.googleapis.com/index.html?path=81.0.4044.69/ and put
+it into PATH.
+
 Run selenium tests via the following command::
 
     $ pytest tests -v

--- a/app.yaml
+++ b/app.yaml
@@ -51,3 +51,6 @@ handlers:
 - url: .*
   script: shell.application
   secure: always
+
+env_variables:
+  PROJECT_ID: "sympy-live-hrd"


### PR DESCRIPTION
Along the lines of: https://github.com/sympy/sympy_gamma/pull/148

NDB Client needs credentials for set up, this is remove the dependency of requiring credentials.
- [x] Use google datastore cloud emulator for testing and development.
- [x] Get `PROJECT_ID` from environment variable.
- [x] Install google cloud SDK in travis.
- [x] Update README.