### PR TITLE
Restructure app, extract constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ install:
   - pip install -r local_requirements.txt
 
 before_script:
+  - cd ..
   - gcloud version || true
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf "$HOME/google-cloud-sdk"; curl https://sdk.cloud.google.com | bash > /dev/null; fi
   - source /home/travis/google-cloud-sdk/path.bash.inc
   - gcloud version
   - gcloud components install cloud-datastore-emulator --quiet
   - gcloud beta emulators datastore start &
-  - cd ..
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip -nv
   - unzip -q google_appengine_1.9.90.zip
   - export SDK_LOCATION="$(pwd)/google_appengine"
@@ -48,7 +48,7 @@ deploy:
   provider: gae
   keyfile: "../client-secret.json"
   project: sympy-live-hrd
-  skip_cleanup: false
+  skip_cleanup: true
   no_promote: true
   version: "$version"
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ deploy:
   provider: gae
   keyfile: "../client-secret.json"
   project: sympy-live-hrd
-  skip_cleanup: true
+  skip_cleanup: false
   no_promote: true
   version: "$version"
   on:

--- a/app.yaml
+++ b/app.yaml
@@ -47,7 +47,7 @@ handlers:
 # endpoint where you want the shell to run, e.g. /shell . You'll also probably
 # want to add login: admin to restrict to admins only.
 - url: .*
-  script: shell.application
+  script: app.shell.application
   secure: always
 
 env_variables:

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,51 @@
+import types
+
+# Types that can't be pickled.
+UNPICKLABLE_TYPES = (
+  types.ModuleType,
+  types.TypeType,
+  types.ClassType,
+  types.FunctionType,
+  )
+
+# Unpicklable statements to seed new sessions with.
+INITIAL_UNPICKLABLES = [
+  "import logging",
+  "import os",
+  "import sys",
+  "from google.cloud import ndb",
+  "from google.appengine.api import users",
+  "from __future__ import division",
+  "from sympy import *",
+]
+
+PREEXEC = """\
+x, y, z, t = symbols('x y z t')
+k, m, n = symbols('k m n', integer=True)
+f, g, h = symbols('f g h', cls=Function)
+"""
+
+PREEXEC_INTERNAL = """\
+_ = None
+def init_printing(*args, **kwargs):
+    print "To change the printing method of SymPy Live, use the settings" + \
+          " in the menu to the right (below on mobile)."
+"""
+
+PREEXEC_MESSAGE = """\
+from __future__ import division
+from sympy import *
+""" + PREEXEC
+
+VERBOSE_MESSAGE = """\
+These commands were executed:
+%(source)s
+Warning: this shell runs with SymPy %(version)s and so examples pulled from
+other documentation may provide unexpected results.
+Documentation can be found at <a href="http://docs.sympy.org/%(version)s">http://docs.sympy.org/%(version)s</a>.\
+"""
+
+VERBOSE_MESSAGE_SPHINX = """\
+These commands were executed:
+%(source)s
+"""

--- a/app/shell.py
+++ b/app/shell.py
@@ -45,15 +45,16 @@ import sys
 import pdb
 import traceback
 import tokenize
-import types
 import json
-import wsgiref.handlers
 import rlcompleter
 import datetime
 
 from StringIO import StringIO
 import six
 # https://github.com/googleapis/python-ndb/issues/249#issuecomment-560957294
+from app.constants import UNPICKLABLE_TYPES, INITIAL_UNPICKLABLES, PREEXEC, PREEXEC_INTERNAL, PREEXEC_MESSAGE, \
+    VERBOSE_MESSAGE, VERBOSE_MESSAGE_SPHINX
+
 six.moves.reload_module(six)
 
 # https://cloud.google.com/appengine/docs/standard/python/issue-requests#requests
@@ -63,8 +64,8 @@ requests_toolbelt.adapters.appengine.monkeypatch()
 
 from google.appengine.api import users
 from google.cloud import ndb
-from google.appengine.ext import webapp
 from google.appengine.ext.webapp import template
+from google.appengine.ext import webapp
 from google.appengine.runtime import DeadlineExceededError
 from google.appengine.runtime.apiproxy_errors import RequestTooLargeError
 
@@ -90,66 +91,18 @@ PRINTERS = {
     'latex': lambda arg: latex(arg, mode="equation*"),
 }
 
+
 def gdb():
     """Enter pdb in Google App Engine. """
     pdb.Pdb(stdin=getattr(sys, '__stdin__'),
             stdout=getattr(sys, '__stderr__')).set_trace(sys._getframe().f_back)
+
 
 # Set to True if stack traces should be shown in the browser, etc.
 _DEBUG = True
 
 # The entity kind for shell sessions. Feel free to rename to suit your app.
 _SESSION_KIND = '_Shell_Session'
-
-# Types that can't be pickled.
-UNPICKLABLE_TYPES = (
-  types.ModuleType,
-  types.TypeType,
-  types.ClassType,
-  types.FunctionType,
-  )
-
-# Unpicklable statements to seed new sessions with.
-INITIAL_UNPICKLABLES = [
-  "import logging",
-  "import os",
-  "import sys",
-  "from google.cloud import ndb",
-  "from google.appengine.api import users",
-  "from __future__ import division",
-  "from sympy import *",
-]
-
-PREEXEC = """\
-x, y, z, t = symbols('x y z t')
-k, m, n = symbols('k m n', integer=True)
-f, g, h = symbols('f g h', cls=Function)
-"""
-
-PREEXEC_INTERNAL = """\
-_ = None
-def init_printing(*args, **kwargs):
-    print "To change the printing method of SymPy Live, use the settings" + \
-          " in the menu to the right (below on mobile)."
-"""
-
-PREEXEC_MESSAGE = """\
-from __future__ import division
-from sympy import *
-""" + PREEXEC
-
-VERBOSE_MESSAGE = """\
-These commands were executed:
-%(source)s
-Warning: this shell runs with SymPy %(version)s and so examples pulled from
-other documentation may provide unexpected results.
-Documentation can be found at <a href="http://docs.sympy.org/%(version)s">http://docs.sympy.org/%(version)s</a>.\
-"""
-
-VERBOSE_MESSAGE_SPHINX = """\
-These commands were executed:
-%(source)s
-"""
 
 
 # The blueprint used to store user queries
@@ -165,6 +118,7 @@ class Searches(ndb.Model):
         method, which conflicts with the query StringProperty of Searches.
         """
         return super(Searches, cls).query(*args, **kwargs)
+
 
 def banner(quiet=False):
     from sympy import __version__ as sympy_version
@@ -641,7 +595,7 @@ class ForceDesktopCookieHandler(webapp.RequestHandler):
         cookie["desktop"]["expires"] = \
         expiration.strftime("%a, %d-%b-%Y %H:%M:%S PST")
         print cookie.output()
-        template_file = os.path.join(os.path.dirname(__file__), 'templates', 'redirect.html')
+        template_file = os.path.join(os.path.dirname(__file__), '../templates', 'redirect.html')
         vars = { 'server_software': os.environ['SERVER_SOFTWARE'],
                  'python_version': sys.version,
                  'user': users.get_current_user(),
@@ -664,7 +618,7 @@ class FrontPageHandler(webapp.RequestHandler):
             else:
                 saved_searches = []
             saved_searches_count = len(saved_searches)
-        template_file = os.path.join(os.path.dirname(__file__), 'templates', 'shell.html')
+        template_file = os.path.join(os.path.dirname(__file__), '../templates', 'shell.html')
 
         vars = {
             'server_software': os.environ['SERVER_SOFTWARE'],
@@ -720,7 +674,7 @@ class CompletionHandler(webapp.RequestHandler):
         else:
             with ndb_client.context():
                 session = Session()
-                session.unpicklables = [ line for line in INITIAL_UNPICKLABLES ]
+                session.unpicklables = [line for line in INITIAL_UNPICKLABLES]
                 session_key = session.put().urlsafe()
 
             live.evaluate(PREEXEC, session)
@@ -795,7 +749,7 @@ class EvaluateHandler(webapp.RequestHandler):
         else:
             with ndb_client.context():
                 session = Session()
-                session.unpicklables = [ line for line in INITIAL_UNPICKLABLES ]
+                session.unpicklables = [line for line in INITIAL_UNPICKLABLES]
                 session_key = session.put().urlsafe()
 
             live.evaluate(PREEXEC, session)

--- a/app/shell.py
+++ b/app/shell.py
@@ -52,8 +52,15 @@ import datetime
 from StringIO import StringIO
 import six
 # https://github.com/googleapis/python-ndb/issues/249#issuecomment-560957294
-from app.constants import UNPICKLABLE_TYPES, INITIAL_UNPICKLABLES, PREEXEC, PREEXEC_INTERNAL, PREEXEC_MESSAGE, \
-    VERBOSE_MESSAGE, VERBOSE_MESSAGE_SPHINX
+from app.constants import (
+    UNPICKLABLE_TYPES,
+    INITIAL_UNPICKLABLES,
+    PREEXEC,
+    PREEXEC_INTERNAL,
+    PREEXEC_MESSAGE,
+    VERBOSE_MESSAGE,
+    VERBOSE_MESSAGE_SPHINX
+)
 
 six.moves.reload_module(six)
 


### PR DESCRIPTION
This is an initial attempt to refactor the app, I plan to refactor most of the app to get rid of one massive file, i.e. `shell.py`, one step at a time. This would help us in upgrading the app, one bit at a time.

- [x] Move shell to app directory
- [x] Extract constant
- [x] Cleanup on travis before deploy