### PR TITLE
Support testing on Firefox browser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,23 +208,33 @@ them you may skip this step. Otherwise to install testing requirements::
 
     $ pip install selenium pytest
 
-For testing you need to download the ``chromedriver``::
+You would also need latest version of one of the supported browsers:
+
+* Chrome: https://www.google.com/chrome/
+* Firefox: https://www.mozilla.org/firefox/new/
+
+You need to download the driver for your browser as well:
+
+For chrome, get the driver for your system from here:
+https://chromedriver.chromium.org/downloads
+
+Here is an example for Linux::
 
     $ wget https://chromedriver.storage.googleapis.com/81.0.4044.69/chromedriver_linux64.zip
     $ unzip -q chromedriver_linux64.zip
 
-Copy the ``chromedriver`` in your ``$HOME/bin/`` directory::
+For Firefox, get the driver for your system from here:
+https://github.com/mozilla/geckodriver/releases
 
-    $ cp chromedriver $HOME/bin/
+After extracting the browser driver from the zip or tar file, for Unix based systems,
+copy the driver to following directory::
+
+    $ mv /path/to/ChromeDriver /usr/local/bin
+    $ mv /path/to/geckodriver /usr/local/bin
+
+For other systems like Windows, you need to put it in PATH.
 
 Now run the application in the background, (See ``dev_appserver`` instructions above to start the app).
-
-You would need Google Chrome browser installed for running these tests:
-Download it from here: https://www.google.com/chrome/
-
-You would also need chrome driver (for your chrome version). Download it from here:
-https://chromedriver.storage.googleapis.com/index.html?path=81.0.4044.69/ and put
-it into PATH.
 
 Run selenium tests via the following command::
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,4 @@
+{
+  "browser": "Headless Chrome",
+  "implicit_wait": 10
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,20 +2,47 @@
 This module contains shared fixtures.
 """
 
+import json
 import pytest
 import selenium.webdriver
 
+CONFIG_PATH = 'tests/config.json'
+SUPPORTED_BROWSERS = ['Firefox', 'Chrome', 'Headless Chrome']
+
 
 @pytest.fixture
-def browser():
+def config(scope='session'):
+
+    # Read the file
+    with open(CONFIG_PATH) as config_file:
+        config = json.load(config_file)
+
+    # Assert values are acceptable
+    assert config['browser'] in SUPPORTED_BROWSERS
+    assert isinstance(config['implicit_wait'], int)
+    assert config['implicit_wait'] > 0
+
+    # Return config so it can be used
+    return config
+
+
+@pytest.fixture
+def browser(config):
 
     # Initialize the WebDriver instance
-    opts = selenium.webdriver.ChromeOptions()
-    opts.add_argument('headless')
-    b = selenium.webdriver.Chrome(options=opts)
+    if config['browser'] == 'Firefox':
+        b = selenium.webdriver.Firefox()
+    elif config['browser'] == 'Chrome':
+        b = selenium.webdriver.Chrome()
+    elif config['browser'] == 'Headless Chrome':
+        opts = selenium.webdriver.ChromeOptions()
+        opts.add_argument('headless')
+        b = selenium.webdriver.Chrome(options=opts)
+    else:
+        raise Exception('Browser "%s" is not supported' % config["browser"])
 
     # Make its calls wait for elements to appear
-    b.implicitly_wait(10)
+    b.implicitly_wait(config['implicit_wait'])
 
     # Return the WebDriver instance for the setup
     yield b

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -10,14 +10,14 @@ from selenium.webdriver.common.keys import Keys
 
 class SymPyLivePage(object):
 
-    URL = 'http://localhost:8080'
+    URL = 'http://localhost:8080/'
 
     def __init__(self, browser):
         self.browser = browser
 
-    def load(self):
+    def load(self, path=''):
         """Loads the URL in the given browser."""
-        self.browser.get(self.URL)
+        self.browser.get(self.URL + path)
 
     def title(self):
         """Returns the title of the page loaded by the browser."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,13 @@
 from pages import SymPyLivePage
 
 
+def test_app_status(browser):
+    live_page = SymPyLivePage(browser)
+    live_page.load('status')
+    response = live_page.browser.find_element_by_tag_name("pre").text
+    assert str(response) == '{"status": "ok"}'
+
+
 def test_page_title(browser):
     live_page = SymPyLivePage(browser)
     live_page.load()


### PR DESCRIPTION
It fixes part of #168 

- [x] Support ability to test on different browser via `config.json`
- [x] Add support for Firefox
- [x] Add test for `status/` endpoint

Next step would be to test it on Travis.