### PR TITLE
Fix pkg_resource import

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,5 +1,4 @@
 import os
-import pkg_resources
 from google.appengine.ext import vendor
 
 # Set path to your libraries folder.
@@ -7,4 +6,6 @@ path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'lib')
 # Add libraries installed in the path folder.
 vendor.add(path)
 # Add libraries to pkg_resources working set to find the distribution.
+
+import pkg_resources
 pkg_resources.working_set.add_entry(path)


### PR DESCRIPTION
Fixes #181 It seems the pkg_resource import was placed before setting library path. This PR fixes that order.