### PR TITLE
Download chromedriver based on Google's instructions

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /usr/src/app
 
 COPY requirements ./requirements
 COPY ./docker/app/run.sh /run.sh
+COPY ./docker/app/get_chrome_driver.py /usr/src/get_chrome_driver.py
 
 RUN pip install -r requirements/requirements.txt -t lib/
 RUN pip install -r requirements/local_requirements.txt
@@ -32,8 +33,7 @@ ENV DISPLAY=:99
 COPY . .
 
 # Install chromedriver
-RUN CHROME_DRIVER_VERSION=$(wget -qO- "https://chromedriver.storage.googleapis.com/LATEST_RELEASE") \
-    && wget https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -P /usr/src/
+RUN python /usr/src/get_chrome_driver.py /usr/src/
 RUN unzip -q /usr/src/chromedriver_linux64.zip -d /usr/local/bin/
 
 ENTRYPOINT [ "/run.sh" ]

--- a/docker/app/get_chrome_driver.py
+++ b/docker/app/get_chrome_driver.py
@@ -1,0 +1,45 @@
+"""Downloads the Chrome driver based on the chrome version
+
+This is based on the innstructions from Google:
+https://chromedriver.chromium.org/downloads/version-selection
+
+"""
+import subprocess
+import urllib2
+import wget
+import sys
+
+CHROME_DRIVER_VERSION_URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_"
+CHROME_DRIVER_DOWNLOAD_URL = "https://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip"
+
+
+def get_chrome_version():
+    print "Getting Chrome Version"
+    google_chrome_version = subprocess.check_output(
+        ["google-chrome-stable", "--product-version"]
+    )
+    chrome_version = google_chrome_version.rsplit('.', 1)[0]
+    print "Chrome Version: %s" % chrome_version
+    return chrome_version
+
+
+def get_chrome_driver_version():
+    chrome_version = get_chrome_version()
+    url = "%s%s" % (CHROME_DRIVER_VERSION_URL, chrome_version)
+    print "Getting Chrome Driver Version from url: %s" % url
+    chromedriver_version = urllib2.urlopen(url).read()
+    print "Chrome Driver Version: %s" % chromedriver_version
+    return chromedriver_version
+
+
+def download_chrome_driver(path):
+    chrome_driver_version = get_chrome_driver_version()
+    print "Downloading Chrome Driver: %s" % chrome_driver_version
+    download_url = CHROME_DRIVER_DOWNLOAD_URL % chrome_driver_version
+    print "Download url: %s" % download_url
+    wget.download(download_url, path)
+
+
+if __name__ == '__main__':
+    download_path = sys.argv[1]
+    download_chrome_driver(download_path)

--- a/requirements/local_requirements.txt
+++ b/requirements/local_requirements.txt
@@ -5,3 +5,4 @@ selenium
 enum34
 nose
 requests
+wget


### PR DESCRIPTION
The current way of downloading chromedriver based on Chrome version is less reliable, this makes it more reliable as per Google's instructions here: https://chromedriver.chromium.org/downloads/version-selection