### PR TITLE
Use JupyterLite for the interactive REPL

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -45,23 +45,6 @@
 
     <script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_CHTML-full"></script>
 
-    <script type="text/javascript">
-      $(document).ready(function() {
-          var shell = new SymPy.Shell({
-              printer: "{{ printer }}",
-              submit: "{{ submit }}",
-              tabWidth: {{ tabWidth }}
-          });
-
-          var el = $('#shell');
-          shell.render(el);
-
-          var statements = utilities.getURLParameter('evaluate');
-          if (statements) {
-              shell.evaluateInitial(statements);
-          }
-      });
-    </script>
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id=UA-163910085-2"></script>
       <script>

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -6,9 +6,8 @@
 <h1>SymPy Live</h1>
 <div id="banner">{{ banner|safe }}</div>
 <iframe
-    id="numpy-shell"
     src="https://replite.vercel.app/retro/consoles/?toolbar=1&kernel=python&code=import%20sympy%20as%20sp"
-    width="600px"
+    width="100%"
     height="500px"
 >
 </iframe>

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -6,7 +6,7 @@
 <h1>SymPy Live</h1>
 <div id="banner">{{ banner|safe }}</div>
 <iframe
-    src="https://replite.vercel.app/retro/consoles/?toolbar=1&kernel=python&code=import%20sympy%20as%20sp"
+    src="https://replite.vercel.app/retro/consoles/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
     width="100%"
     height="500px"
 >

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -5,7 +5,13 @@
 {% block content %}
 <h1>SymPy Live</h1>
 <div id="banner">{{ banner|safe }}</div>
-<div id="shell"></div>
+<iframe
+    id="numpy-shell"
+    src="https://replite.vercel.app/retro/consoles/?toolbar=1&kernel=python&code=import%20sympy%20as%20sp"
+    width="600px"
+    height="500px"
+>
+</iframe>
 {% endblock %}
 
 {% block sidebar %}

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -6,7 +6,7 @@
 <h1>SymPy Live</h1>
 <div id="banner">{{ banner|safe }}</div>
 <iframe
-    src="https://replite.vercel.app/retro/consoles/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
+    src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
     width="100%"
     height="500px"
 >


### PR DESCRIPTION
Fixes https://github.com/sympy/sympy-live/issues/83

Similar to https://github.com/numpy/numpy.org/pull/547

JupyterLite is a JupyterLab distribution that runs entirely in the web browser, backed by in-browser language kernels including the WebAssembly powered [Pyodide](https://pyodide.org) kernel.

The embeddable code console is currently deployed as a static website on Vercel, and the source code is currently living in the following repository: https://github.com/jtpio/replite

It supports rich rendering of outputs just like in Jupyter Notebook and JupyterLab, for example:

![image](https://user-images.githubusercontent.com/591645/152344748-f083ce00-f575-438d-9793-462058c1f68d.png)

**TODO**

- [x] Embed `replite` in an `iframe`
- [x] ~Remove previous shell from the code base~ -> can be done as follow-up, especially since only a static website should now be required
- [x] Execute more code by default:

```
>>> from __future__ import division
>>> from sympy import *
>>> x, y, z, t = symbols('x y z t')
>>> k, m, n = symbols('k m n', integer=True)
>>> f, g, h = symbols('f g h', cls=Function)
```