### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Start Docker compose
+      run: |
+        docker-compose up -d
+        sleep 10
+    - name: Run Tests
+      run: |
+        docker-compose exec app pytest tests/ -v


### PR DESCRIPTION
Travis is gone, and the repo is CI-less at the moment. This adds CI via GitHub Actions.